### PR TITLE
Change highlighting of bracket string delimiters

### DIFF
--- a/hy-font-lock.el
+++ b/hy-font-lock.el
@@ -435,6 +435,22 @@
    '(0 font-lock-function-name-face))
   "Hylight tag macros, ie. `#tag-macro', so they stand out.")
 
+(defconst hy-font-lock--bracket-string-delimiters
+  (list
+   (rx
+    (group-n 1
+	     "#["
+	     (group-n 2 (zero-or-more (not ?\[)))
+	     ?\[)
+    (group-n 3 (* (not (| ?\[ ?\]))))
+    (group-n 4
+	     ?\]
+	     (backref 2)
+	     ?\]))
+   '(1 font-lock-comment-face)
+   '(4 font-lock-comment-face))
+  "Highlight the bracket-string delimiters.")
+
 ;;;; Misc
 
 (defconst hy-font-lock--kwds-anonymous-funcs
@@ -603,6 +619,7 @@ applied with success to `ielm'."
         hy-font-lock--kwds-tag-macros
         hy-font-lock--kwds-unpacking
         hy-font-lock--kwds-variables
+	hy-font-lock--bracket-string-delimiters
 
         ;; Advanced kwds
         hy-font-lock--kwds-tag-comment-prefix

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -142,8 +142,8 @@ and determined by `font-lock-mode' internals when making an edit to a buffer."
       (let ((a (match-beginning 1))
             (b (match-end 1))
             (string-fence (string-to-syntax "|")))
-        (put-text-property (1- a) a 'syntax-table string-fence)
-        (put-text-property b (1+ b) 'syntax-table string-fence)))))
+        (put-text-property a (1+ a) 'syntax-table string-fence)
+        (put-text-property (1- b) b 'syntax-table string-fence)))))
 
 ;;; Indentation
 ;;;; Normal Indent


### PR DESCRIPTION
I like the delimiters to be distinguishable from the string content
itself, so this commit makes the delimiters ( #[foo?[, ]foo?] )
highlight with the comment face, and the contents highlight with the
string face.